### PR TITLE
capitalize project name

### DIFF
--- a/inst/rstudio/templates/project/make_project.dcf
+++ b/inst/rstudio/templates/project/make_project.dcf
@@ -1,2 +1,2 @@
 Binding: make_project
-Title: DCL project
+Title: DCL Project


### PR DESCRIPTION
All the other projects capitalize "Project," so ours looks sort of out of place