### PR TITLE
Increased resolution for knitted plots from 72 to 150 dots per inch

### DIFF
--- a/inst/rmarkdown/templates/github/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/github/skeleton/skeleton.Rmd
@@ -8,7 +8,7 @@ output:
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
+knitr::opts_chunk$set(echo = TRUE, dpi = 150)
 ```
 
 ```{r message=FALSE, warning=FALSE}


### PR DESCRIPTION
Resolution is by default 72 dots per inch, which can create poor-looking plots. I changed it to 150 dots per inch for crisper-looking plots. 

If this works on Mac and Windows, I think it would be good to have the default template create higher-than-before-resolution plots. 